### PR TITLE
Add the possibility of having multiples templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /composer.lock
 /.idea/*
-/tests/Functional/templates/mjml/*.html.twig
+/tests/Functional/templates/**/*html.twig
 /tests/Functional/var/*
 /vendor/*

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -12,22 +12,15 @@ class Compiler
 
     private $mjmlCompiler;
 
-    private $htmlDir;
-
     private $tmpDir;
 
     public function __construct(
         CustomCompiler $customCompiler,
         MjmlCompiler $mjmlCompiler,
-        string $cacheDir,
-        string $projectDir
+        string $cacheDir
     ) {
         $this->customCompiler = $customCompiler;
         $this->mjmlCompiler = $mjmlCompiler;
-
-        // HTML folder
-        $this->htmlDir = $projectDir . '/templates/mjml';
-        $this->ensureDirExists($this->htmlDir);
 
         // Tmp folder
         $this->tmpDir = $cacheDir . '/assoconnect/mjml';
@@ -57,7 +50,7 @@ class Compiler
 
         // MJML => HTML
         $htmlFilename = str_replace('.mjml.', '.html.', $file->getFilename());
-        $htmlFile = $this->htmlDir . '/' . $htmlFilename;
+        $htmlFile = $file->getPath() . '/' . $htmlFilename;
         $this->mjmlCompiler->compile($mjmlFile, $htmlFile);
     }
 

--- a/src/DependencyInjection/AssoconnectMJMLExtension.php
+++ b/src/DependencyInjection/AssoconnectMJMLExtension.php
@@ -21,6 +21,11 @@ class AssoconnectMJMLExtension extends Extension
         );
         $loader->load('services.yaml');
 
+        $configuration = new Configuration();
+
+        $config = $this->processConfiguration($configuration, $configs);
+        $container->setParameter('assoconnect_mjml.template_paths', $config['template_paths']);
+
         // all classes implementing TagInterface will be tagged with assoconnect_mjml.custom_tag
         // so the bundle user does not need to tag these
         $container->registerForAutoconfiguration(TagInterface::class)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Assoconnect\MJMLBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('assoconnect_mjml');
+
+        $rootNode
+            ->children()
+                ->arrayNode('template_paths')
+                    ->beforeNormalization()
+                        ->ifString()->then(function ($v) {
+                            return [$v];
+                        })
+                        ->end()
+                    ->prototype('scalar')->end()
+                    ->defaultValue(['/templates/mjml'])
+                ->end() // template_paths
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/Finder/DuplicatesTemplatesNameException.php
+++ b/src/Finder/DuplicatesTemplatesNameException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assoconnect\MJMLBundle\Finder;
+
+class DuplicatesTemplatesNameException extends \RuntimeException
+{
+
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -11,8 +11,6 @@ services:
             $customCompiler: "@assoconnect_mjml.custom_compiler"
             $mjmlCompiler: "@assoconnect_mjml.mjml_compiler"
             $cacheDir: "%kernel.cache_dir%"
-            $projectDir: "%kernel.project_dir%"
-
 
     assoconnect_mjml.mjml_compiler:
         class: Assoconnect\MJMLBundle\Compiler\MjmlCompiler
@@ -21,6 +19,7 @@ services:
         class: Assoconnect\MJMLBundle\Finder\TemplateFinder
         arguments:
             $projectDir: "%kernel.project_dir%"
+            $templatePaths: "%assoconnect_mjml.template_paths%"
 
     assoconnect_mjml.cache_warmer:
         class: Assoconnect\MJMLBundle\CacheWarmer\CompileCacheWarmer

--- a/src/Resources/doc/index.md
+++ b/src/Resources/doc/index.md
@@ -89,6 +89,13 @@ HTML files are generated on Symfony cache warm-up and are in the same folder but
 This files should not be commited to your GIT repository: ignore them with this rule `/template/mjml/*.html.twig` in `/.gitignore` file.
 If you are using Symfony 4, you do not need to create this rule as this bundle comes with a recipe that takes care of it.
 
+If you need multiple templates paths or don't want to put templates in `/templates/mjml`, then add a config like this :
+```
+assoconnect_mjml:
+    template_paths:
+        - /templates/mjml
+        - /templates/folder/subfolder/mjml
+```
 Compile command
 ---------------
 

--- a/tests/Finder/TemplateFinderTest.php
+++ b/tests/Finder/TemplateFinderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Assoconnect\MJMLBundle\Tests\Finder;
 
+use Assoconnect\MJMLBundle\Finder\DuplicatesTemplatesNameException;
 use Assoconnect\MJMLBundle\Finder\TemplateFinder;
 use PHPUnit\Framework\TestCase;
 
@@ -11,7 +12,7 @@ class TemplateFinderTest extends TestCase
 {
     public function testFindDefault()
     {
-        $finder = new TemplateFinder(__DIR__ . '/../Functional');
+        $finder = new TemplateFinder(__DIR__ . '/../Functional', ['/templates/mjml/']);
 
         $templates = $finder->find();
 
@@ -23,7 +24,7 @@ class TemplateFinderTest extends TestCase
 
     public function testFindOne()
     {
-        $finder = new TemplateFinder(__DIR__ . '/../Functional');
+        $finder = new TemplateFinder(__DIR__ . '/../Functional', ['/templates/mjml/']);
 
         $templates = $finder->find('custom.mjml.twig');
 
@@ -33,9 +34,46 @@ class TemplateFinderTest extends TestCase
         $this->assertSame('custom.mjml.twig', $template->getFilename());
     }
 
+    public function testFindTwo()
+    {
+        $finder = new TemplateFinder(__DIR__ . '/../Functional', [
+            '/templates/mjml/',
+            '/templates/folder/subfolder/mjml/'
+        ]);
+
+        $templates = $finder->find('custom.mjml.twig');
+
+        //first template
+        $this->assertCount(1, $templates);
+
+        $template = array_pop($templates);
+        $this->assertSame('custom.mjml.twig', $template->getFilename());
+
+        //second template
+        $templates = $finder->find('custom_path.mjml.twig');
+
+        $this->assertCount(1, $templates);
+
+        $template = array_pop($templates);
+        $this->assertSame('custom_path.mjml.twig', $template->getFilename());
+    }
+
+    public function testFindDuplicates()
+    {
+        $finder = new TemplateFinder(__DIR__ . '/../Functional', [
+            '/templates/mjml/',
+            '/templates/folder/subfolder/mjml/',
+            '/templates/folderWithDuplicates/subfolder/mjml/'
+        ]);
+
+        $this->expectException(DuplicatesTemplatesNameException::class);
+        $this->expectExceptionMessage('Duplicates template name found custom_path.mjml.twig');
+        $finder->find('custom_path.mjml.twig');
+    }
+
     public function testNotFound()
     {
-        $finder = new TemplateFinder(__DIR__ . '/../Functional');
+        $finder = new TemplateFinder(__DIR__ . '/../Functional', ['/templates/mjml/']);
 
         $templates = $finder->find('not_found.mjml.twig');
 

--- a/tests/Functional/config/config.yml
+++ b/tests/Functional/config/config.yml
@@ -11,3 +11,8 @@ services:
         resource: '../src/Tag/*'
         tags: [ 'assoconnect_mjml.custom_tag' ]
 
+assoconnect_mjml:
+    template_paths:
+        - /templates/mjml
+        - /templates/folder/subfolder/mjml
+

--- a/tests/Functional/templates/folder/subfolder/mjml/custom_path.mjml.twig
+++ b/tests/Functional/templates/folder/subfolder/mjml/custom_path.mjml.twig
@@ -1,0 +1,9 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+        <mj-column>
+            in custom_path
+        </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/tests/Functional/templates/folderWithDuplicates/subfolder/mjml/custom_path.mjml.twig
+++ b/tests/Functional/templates/folderWithDuplicates/subfolder/mjml/custom_path.mjml.twig
@@ -1,0 +1,9 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+        <mj-column>
+            in custom_path
+        </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
In large project, templates can be classified in multiples folders.  This commit to add the possibility of having multiples templates path by adding a `template_paths`configuration in a `assoconnect_mjml` key in configuration.

```yaml
assoconnect_mjml:
    template_paths:
        - /templates/mjml
        - /templates/folder/subfolder/mjml
``` 

By default, no need to add that key and default value of `template_paths`is `[/templates/mjml]` as it used to be before.