### PR TITLE
Add external mjml renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /tests/Functional/templates/**/*html.twig
 /tests/Functional/var/*
 /vendor/*
+phpcs.phar
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "php": "^7.2",
     "symfony/framework-bundle": "^4.2",
     "symfony/process": "^4.2",
-    "symfony/console": "^4.2"
+    "symfony/console": "^4.2",
+    "guzzlehttp/guzzle": "~6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1",

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -16,7 +16,7 @@ class Compiler
 
     public function __construct(
         CustomCompiler $customCompiler,
-        MjmlCompiler $mjmlCompiler,
+        MjmlCompilerInterface $mjmlCompiler,
         string $cacheDir
     ) {
         $this->customCompiler = $customCompiler;

--- a/src/Compiler/MjmlCompiler.php
+++ b/src/Compiler/MjmlCompiler.php
@@ -9,7 +9,7 @@ use Symfony\Component\Process\Process;
 /**
  * Compiles a MJML file to an HTML file
  */
-class MjmlCompiler
+class MjmlCompiler implements MjmlCompilerInterface
 {
     public function compile(string $input, string $output)
     {

--- a/src/Compiler/MjmlCompilerInterface.php
+++ b/src/Compiler/MjmlCompilerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assoconnect\MJMLBundle\Compiler;
+
+interface MjmlCompilerInterface
+{
+    public function compile(string $input, string $output);
+}

--- a/src/Compiler/RestMjmlCompiler.php
+++ b/src/Compiler/RestMjmlCompiler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assoconnect\MJMLBundle\Compiler;
+
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Compiles a MJML file to an HTML file
+ */
+class RestMjmlCompiler implements MjmlCompilerInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    public function compile(string $input, string $output)
+    {
+        $response = $this->client->request('post', '/', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'json' => [
+                'mjml' => file_get_contents($input)
+            ]
+        ]);
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        file_put_contents($output, $json['html']);
+    }
+}

--- a/src/DependencyInjection/AssoconnectMJMLExtension.php
+++ b/src/DependencyInjection/AssoconnectMJMLExtension.php
@@ -25,6 +25,7 @@ class AssoconnectMJMLExtension extends Extension
 
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('assoconnect_mjml.template_paths', $config['template_paths']);
+        $container->setParameter('assoconnect_mjml.rest_mjml_compiler_host', $config['rest_mjml_compiler_host']);
 
         // all classes implementing TagInterface will be tagged with assoconnect_mjml.custom_tag
         // so the bundle user does not need to tag these

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,9 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                     ->defaultValue(['/templates/mjml'])
                 ->end() // template_paths
+                ->variableNode('rest_mjml_compiler_host')
+                    ->defaultValue('http://127.0.0.1:3000')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Finder/TemplateFinder.php
+++ b/src/Finder/TemplateFinder.php
@@ -61,7 +61,7 @@ class TemplateFinder
                 $duplicates[] = $val;
             }
         }
-
+        
         if (array_count_values($duplicates)) {
             throw new DuplicatesTemplatesNameException(sprintf(
                 'Duplicates template name found %s',

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -9,8 +9,17 @@ services:
         class: Assoconnect\MJMLBundle\Compiler\Compiler
         arguments:
             $customCompiler: "@assoconnect_mjml.custom_compiler"
-            $mjmlCompiler: "@assoconnect_mjml.mjml_compiler"
+            $mjmlCompiler: "@assoconnect_mjml.mjml_compiler_service"
             $cacheDir: "%kernel.cache_dir%"
+
+    assoconnect_mjml.rest_mjml_compiler_client:
+      class: GuzzleHttp\Client
+      public: true
+      arguments:
+        - base_uri: '%assoconnect_mjml.rest_mjml_compiler_host%'
+
+    assoconnect_mjml.mjml_compiler_service:
+      alias: assoconnect_mjml.mjml_compiler
 
     assoconnect_mjml.mjml_compiler:
         class: Assoconnect\MJMLBundle\Compiler\MjmlCompiler

--- a/src/Resources/doc/index.md
+++ b/src/Resources/doc/index.md
@@ -171,3 +171,40 @@ The bundle processes the templates in two steps:
 2. Compiling MJML tags to HTML tags
 
 During the first step, the bundle creates temporary files in the `%kernel.cache_dir%/assoconnect_mjml`. You may review their content with the [live editor](https://mjml.io/try-it-live) for debugging purpose. 
+
+Using an external REST mjml compiler 
+------------------------------------
+If you don't want to install mjml locally, you can use a external rest mjml compiler
+
+**Configuration**
+ 
+To do so, modify your configuration as follow:
+```yaml
+assoconnect_mjml:
+    rest_mjml_compiler_host: "http://mjml-rest-server-address:3000"
+
+```
+you also have to alias `assoconnect_mjml.mjml_compiler_service` to `assoconnect_mjml.rest_mjml_compiler` in services.yaml
+```yaml
+services:
+....
+    assoconnect_mjml.mjml_compiler_service:
+        alias: assoconnect_mjml.rest_mjml_compiler
+```
+
+**Mjml rest service** 
+
+The mjml rest service must be a `post` route accepting a json as parameter containing one key:
+```
+```json
+{
+  "mjml":"<mjml><mj-body>....</mj-body></mjml>"
+}
+```  
+returning format is a json  
+```json
+{
+  "html":"<body>....</body>"
+}
+```
+example in https://github.com/micoli/docker-mjml-server

--- a/tests/Functional/config/config_rest.yml
+++ b/tests/Functional/config/config_rest.yml
@@ -1,0 +1,38 @@
+framework:
+    secret: test
+
+services:
+    Assoconnect\MJMLBundle\Tests\Functional\App\:
+        public: true
+        resource: '../src/*'
+
+    assoconnect_mjml.mjml_compiler_service:
+        alias: assoconnect_mjml.rest_mjml_compiler
+
+    Assoconnect\MJMLBundle\Tests\Functional\App\Tag\:
+        public: true
+        resource: '../src/Tag/*'
+        tags: [ 'assoconnect_mjml.custom_tag' ]
+
+    assoconnect_mjml.rest_mjml_compiler_client:
+        class: GuzzleHttp\Client
+        public: true
+        arguments:
+            - base_uri: '%assoconnect_mjml.rest_mjml_compiler_host%'
+              handler: '@assoconnect_mjml.rest_mjml_compiler_client_handler_stack'
+
+    assoconnect_mjml.rest_mjml_compiler_client_handler_stack_factory:
+        class: Assoconnect\MJMLBundle\Tests\RestCompiler\RestCompilerHandlerStackFactory
+        arguments:
+            $temporaryDirectory : "%kernel.cache_dir%"
+
+    assoconnect_mjml.rest_mjml_compiler_client_handler_stack:
+        class: GuzzleHttp\HandlerStack
+        factory: ['@assoconnect_mjml.rest_mjml_compiler_client_handler_stack_factory','create']
+
+assoconnect_mjml:
+    rest_mjml_compiler_host: "http://192.168.99.100:3002"
+    template_paths:
+        - /templates/mjml
+        - /templates/folder/subfolder/mjml
+

--- a/tests/Functional/src/RestTestKernel.php
+++ b/tests/Functional/src/RestTestKernel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assoconnect\MJMLBundle\Tests\Functional\App;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class RestTestKernel extends TestKernel
+{
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__ . '/../config/config_rest.yml');
+    }
+}

--- a/tests/RestCompiler/RestCompilerHandlerStackFactory.php
+++ b/tests/RestCompiler/RestCompilerHandlerStackFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assoconnect\MJMLBundle\Tests\RestCompiler;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Component\Process\Process;
+
+class RestCompilerHandlerStackFactory
+{
+    /**
+     * @var string
+     */
+    private $temporaryDirectory;
+
+    public function __construct(string $temporaryDirectory)
+    {
+        $this->temporaryDirectory = $temporaryDirectory;
+    }
+
+    public function create(): HandlerStack
+    {
+        return HandlerStack::create(new MockHandler(array_fill(0, 10, function (Request $a) {
+            $temporaryFilename = tempnam($this->temporaryDirectory, 'mjml-rest-') . '.txt';
+            $requestBodyObject = json_decode($a->getBody()->getContents(), true);
+            file_put_contents($temporaryFilename, $requestBodyObject['mjml']);
+
+            $command = [
+                'mjml',
+                $temporaryFilename,
+                '-o',
+                $temporaryFilename,
+                '--config.validationLevel=strict',
+            ];
+            $process = new Process($command);
+            $process->mustRun();
+
+            $response = new Response(200, [
+                'X-Server' => 'fake-mjml-server'
+            ], json_encode([
+                'html' => file_get_contents($temporaryFilename)
+            ]));
+            unlink($temporaryFilename);
+
+            return $response;
+        })));
+    }
+}

--- a/tests/RestCompiler/RestCompilerTest.php
+++ b/tests/RestCompiler/RestCompilerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assoconnect\MJMLBundle\Tests\RestCompiler;
+
+use Assoconnect\MJMLBundle\Tests\Functional\App\RestTestKernel;
+use Assoconnect\MJMLBundle\Tests\Functional\App\TestCase;
+
+class RestCompilerTest extends TestCase
+{
+    public static function getKernelClass()
+    {
+        return RestTestKernel::class;
+    }
+
+    public function testSuccess()
+    {
+        // Kernel booting will clear the cache and warm it up
+        self::bootKernel();
+        $this->helperSuccess();
+    }
+}


### PR DESCRIPTION
If you don't want to install mjml and nodejs aside with your symfony project, you can use an external mjml compiler(https://github.com/micoli/docker-mjml-server) with the following code. 